### PR TITLE
SDK-154 set pod to use static libraries

### DIFF
--- a/scripts/deploy-release
+++ b/scripts/deploy-release
@@ -44,5 +44,5 @@ git pull origin $git_branch
 git push
 
 # Remove `--allow-warnings` when Adobe fixes their warnings.
-pod spec lint --allow-warnings
-pod trunk push --allow-warnings AdobeBranchExtension.podspec
+pod spec lint --allow-warnings --use-libraries
+pod trunk push --allow-warnings --use-libraries AdobeBranchExtension.podspec

--- a/scripts/deploy-release
+++ b/scripts/deploy-release
@@ -22,7 +22,7 @@ project_directory="$(full_path_of_directory AdobeBranchExtension-iOS)"
 cd "$project_directory"
 
 # Remove `--allow-warnings` when Adobe fixes their warnings.
-pod lib lint --allow-warnings
+pod lib lint --allow-warnings --use-libraries
 
 version="$(./scripts/version)"
 git_branch=$(git symbolic-ref --short HEAD)


### PR DESCRIPTION
The release script needs to be modified slightly to let cocoapods know we're linking against static libraries too.

Adding the --use-libraries flag should be sufficient.

Documentation:
pod trunk push --help
pod lib lint --help

Verify from command line

This version will throw a header error
pod lib lint --allow-warnings  

This version will lint correctly
pod lib lint --allow-warnings --use-libraries 
