### PR TITLE
update adobe pod dependancy from ACPCoreBeta to ACPCore

### DIFF
--- a/AdobeBranchExtension.podspec
+++ b/AdobeBranchExtension.podspec
@@ -21,6 +21,6 @@ their app content to improve discoverability and optimize mobile campaigns.
 
   s.source_files     = 'AdobeBranchExtension/Classes/**/*'
 
-  s.dependency 'ACPCoreBeta',   '= 2.0.0beta2'
+  s.dependency 'ACPCore',   '= 2.0.3'
   s.dependency 'Branch',        '>= 0.25.9'
 end

--- a/AdobeBranchExtension.podspec
+++ b/AdobeBranchExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AdobeBranchExtension"
-  s.version          = "0.1.6"
+  s.version          = "0.1.7"
   s.summary          = "The Branch extension for Adobe Cloud Platform on iOS."
 
   s.description      = <<-DESC

--- a/Examples/AdobeBranchExample/Podfile
+++ b/Examples/AdobeBranchExample/Podfile
@@ -2,6 +2,6 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '10.0'
 
 target 'AdobeBranchExample' do
-  pod 'ACPCoreBeta' # ,  '>= 1.0.1beta'
+  pod 'ACPCore' # ,  '>= 1.0.1beta'
   pod 'AdobeBranchExtension', :path => '../../'
 end


### PR DESCRIPTION
The Adobe team has move their core "Adobe Experience Platform" SDK out of beta, and we need to update our pod dependency to point at the non-beta version.