### PR TITLE
SDK-269 improve swift compatibility.

### DIFF
--- a/AdobeBranchExtension.podspec
+++ b/AdobeBranchExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AdobeBranchExtension"
-  s.version          = "0.1.8"
+  s.version          = "1.0.0"
   s.summary          = "The Branch extension for Adobe Cloud Platform on iOS."
 
   s.description      = <<-DESC

--- a/AdobeBranchExtension.podspec
+++ b/AdobeBranchExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AdobeBranchExtension"
-  s.version          = "0.1.7"
+  s.version          = "0.1.8"
   s.summary          = "The Branch extension for Adobe Cloud Platform on iOS."
 
   s.description      = <<-DESC
@@ -18,9 +18,10 @@ their app content to improve discoverability and optimize mobile campaigns.
 
   s.platform         = :ios, '10.0'
   s.requires_arc     = true
+  s.static_framework = true
 
   s.source_files     = 'AdobeBranchExtension/Classes/**/*'
 
-  s.dependency 'ACPCore',   '= 2.0.3'
-  s.dependency 'Branch',        '>= 0.25.9'
+  s.dependency 'ACPCore',   '= 2.1.0'
+  s.dependency 'Branch',    '= 0.26.0'
 end

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.h
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.h
@@ -8,8 +8,8 @@
 
 #import <Foundation/Foundation.h>
 #import <Branch/Branch.h>
-#import "ACPCore.h"
-#import "ACPExtension.h"
+#import <ACPCore/ACPCore.h>
+#import <ACPCore/ACPExtension.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
@@ -11,7 +11,7 @@
 
 #pragma mark Constants
 
-NSString*const ABEBranchExtensionVersion        = @"0.1.6";
+NSString*const ABEBranchExtensionVersion        = @"0.1.8";
 
 NSString*const ABEBranchEventType               = @"com.branch.eventType";
 NSString*const ABEBranchEventSource             = @"com.branch.eventSource";

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
@@ -11,7 +11,7 @@
 
 #pragma mark Constants
 
-NSString*const ABEBranchExtensionVersion        = @"0.1.8";
+NSString*const ABEBranchExtensionVersion        = @"1.0.0";
 
 NSString*const ABEBranchEventType               = @"com.branch.eventType";
 NSString*const ABEBranchEventSource             = @"com.branch.eventSource";
@@ -51,7 +51,7 @@ NSString*const ABEBranchEventSource             = @"com.branch.eventSource";
             branchInstance = [Branch getInstance];
         }
     });
-    
+
     return branchInstance;
 }
 
@@ -147,7 +147,7 @@ NSMutableDictionary *BNCStringDictionaryWithDictionary(NSDictionary*dictionary_)
 
     #define stringForKey(key) \
         BNCStringWithObject(dictionary[@#key])
-    
+
     NSString *value = stringForKey(currency);
     if (value.length) event.currency = value;
 
@@ -175,7 +175,7 @@ NSMutableDictionary *BNCStringDictionaryWithDictionary(NSDictionary*dictionary_)
     if (value.length) event.searchQuery = value;
 
     #undef stringForKey
-    
+
     event.customData = BNCStringDictionaryWithDictionary(dictionary);
     return event;
 }

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionListener.h
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionListener.h
@@ -7,8 +7,8 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "ACPCore.h"
-#import "ACPExtension.h"
+#import <ACPCore/ACPCore.h>
+#import <ACPCore/ACPExtension.h>
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
This should fix a configuration issue with swift.  

We missed the static framework, forcing users to set the use_modular_headers!.  Which is less than ideal.  