### PR TITLE
INTENG 5176 allow client control over events

### DIFF
--- a/AdobeBranchExtension.podspec
+++ b/AdobeBranchExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AdobeBranchExtension"
-  s.version          = "1.0.1"
+  s.version          = "1.1.0"
   s.summary          = "The Branch extension for Adobe Cloud Platform on iOS."
 
   s.description      = <<-DESC

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.h
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.h
@@ -34,7 +34,7 @@ FOUNDATION_EXPORT NSString*const ABEBranchEventSource;
 
 + (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary *)options;
 
-+ (void)configureEventTypes:(NSArray<NSString *> *)eventTypes andEventSources:(NSArray<NSString *> *)eventSources;
++ (void)configureEventTypes:(nullable NSArray<NSString *> *)eventTypes andEventSources:(nullable NSArray<NSString *> *)eventSources;
 
 - (void)handleEvent:(ACPExtensionEvent*)event;
 

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.h
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.h
@@ -34,6 +34,8 @@ FOUNDATION_EXPORT NSString*const ABEBranchEventSource;
 
 + (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary *)options;
 
++ (void)configureEventTypes:(NSArray<NSString *> *)eventTypes andEventSources:(NSArray<NSString *> *)eventSources;
+
 - (void)handleEvent:(ACPExtensionEvent*)event;
 
 @end

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
@@ -69,17 +69,16 @@ NSString*const ABEBranchEventSource             = @"com.branch.eventSource";
 }
 
 + (void)configureEventTypes:(nullable NSArray<NSString *> *)eventTypes andEventSources:(nullable NSArray<NSString *> *)eventSources {
-    AdobeBranchExtensionConfig *config = [AdobeBranchExtensionConfig instance];
     if (eventTypes) {
-        config.eventTypes = eventTypes;
+        [AdobeBranchExtensionConfig instance].eventTypes = eventTypes;
     } else {
-        config.eventTypes = @[];
+        [AdobeBranchExtensionConfig instance].eventTypes = @[];
     }
     
     if (eventSources) {
-        config.eventSources = eventSources;
+        [AdobeBranchExtensionConfig instance].eventSources = eventSources;
     } else {
-        config.eventSources = @[];
+        [AdobeBranchExtensionConfig instance].eventSources = @[];
     }
 }
 
@@ -109,9 +108,8 @@ NSString*const ABEBranchEventSource             = @"com.branch.eventSource";
 - (void)handleEvent:(ACPExtensionEvent*)event {
     BNCLogDebug(@"Event: %@", event);
 
-    AdobeBranchExtensionConfig *config = [AdobeBranchExtensionConfig instance];
-    if ([config.eventTypes containsObject:event.eventType] &&
-        [config.eventSources containsObject:event.eventSource]) {
+    if ([[AdobeBranchExtensionConfig instance].eventTypes containsObject:event.eventType] &&
+        [[AdobeBranchExtensionConfig instance].eventSources containsObject:event.eventSource]) {
         [self trackEvent:event];
         return;
     }

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
@@ -69,16 +69,17 @@ NSString*const ABEBranchEventSource             = @"com.branch.eventSource";
 }
 
 + (void)configureEventTypes:(nullable NSArray<NSString *> *)eventTypes andEventSources:(nullable NSArray<NSString *> *)eventSources {
+    AdobeBranchExtensionConfig *config = [AdobeBranchExtensionConfig instance];
     if (eventTypes) {
-        [AdobeBranchExtensionConfig instance].eventTypes = eventTypes;
+        config.eventTypes = eventTypes;
     } else {
-        [AdobeBranchExtensionConfig instance].eventTypes = @[];
+        config.eventTypes = @[];
     }
     
     if (eventSources) {
-        [AdobeBranchExtensionConfig instance].eventSources = eventSources;
+        config.eventSources = eventSources;
     } else {
-        [AdobeBranchExtensionConfig instance].eventSources = @[];
+        config.eventSources = @[];
     }
 }
 
@@ -108,8 +109,9 @@ NSString*const ABEBranchEventSource             = @"com.branch.eventSource";
 - (void)handleEvent:(ACPExtensionEvent*)event {
     BNCLogDebug(@"Event: %@", event);
 
-    if ([[AdobeBranchExtensionConfig instance].eventTypes containsObject:event.eventType] &&
-        [[AdobeBranchExtensionConfig instance].eventSources containsObject:event.eventSource]) {
+    AdobeBranchExtensionConfig *config = [AdobeBranchExtensionConfig instance];
+    if ([config.eventTypes containsObject:event.eventType] &&
+        [config.eventSources containsObject:event.eventSource]) {
         [self trackEvent:event];
         return;
     }

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
@@ -12,7 +12,7 @@
 
 #pragma mark Constants
 
-NSString*const ABEBranchExtensionVersion        = @"1.0.1";
+NSString*const ABEBranchExtensionVersion        = @"1.1.0";
 
 NSString*const ABEBranchEventType               = @"com.branch.eventType";
 NSString*const ABEBranchEventSource             = @"com.branch.eventSource";

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
@@ -68,12 +68,17 @@ NSString*const ABEBranchEventSource             = @"com.branch.eventSource";
     return [[self bnc_branchInstance] application:application openURL:url options:options];
 }
 
-+ (void)configureEventTypes:(NSArray<NSString *> *)eventTypes andEventSources:(NSArray<NSString *> *)eventSources {
++ (void)configureEventTypes:(nullable NSArray<NSString *> *)eventTypes andEventSources:(nullable NSArray<NSString *> *)eventSources {
     if (eventTypes) {
         [AdobeBranchExtensionConfig instance].eventTypes = eventTypes;
+    } else {
+        [AdobeBranchExtensionConfig instance].eventTypes = @[];
     }
+    
     if (eventSources) {
         [AdobeBranchExtensionConfig instance].eventSources = eventSources;
+    } else {
+        [AdobeBranchExtensionConfig instance].eventSources = @[];
     }
 }
 

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionConfig.h
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionConfig.h
@@ -1,0 +1,20 @@
+//
+//  AdobeBranchExtensionConfig.h
+//  Pods
+//
+//  Created by Ernest Cho on 4/11/19.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface AdobeBranchExtensionConfig : NSObject
+@property (nonatomic, strong, readwrite) NSArray<NSString *> *eventTypes;
+@property (nonatomic, strong, readwrite) NSArray<NSString *> *eventSources;
+
++ (AdobeBranchExtensionConfig *)instance;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionConfig.m
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionConfig.m
@@ -1,0 +1,31 @@
+//
+//  AdobeBranchExtensionConfig.m
+//  Pods
+//
+//  Created by Ernest Cho on 4/11/19.
+//
+
+#import "AdobeBranchExtensionConfig.h"
+
+@implementation AdobeBranchExtensionConfig
+
++ (AdobeBranchExtensionConfig *)instance {
+    static AdobeBranchExtensionConfig *config;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        config = [AdobeBranchExtensionConfig new];
+    });
+    return config;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        // default event type and source to track, client can override
+        self.eventTypes = @[ @"com.adobe.eventType.generic.track" ];
+        self.eventSources = @[ @"com.adobe.eventSource.requestContent" ];
+    }
+    return self;
+}
+
+@end

--- a/Examples/AdobeBranchExample/AdobeBranchExample.xcodeproj/project.pbxproj
+++ b/Examples/AdobeBranchExample/AdobeBranchExample.xcodeproj/project.pbxproj
@@ -398,10 +398,6 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = R63EM248DP;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Pods/ACPCoreBeta",
-				);
 				INFOPLIST_FILE = "$(SRCROOT)/AdobeBranchExample/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -424,10 +420,6 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = R63EM248DP;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Pods/ACPCoreBeta",
-				);
 				INFOPLIST_FILE = "$(SRCROOT)/AdobeBranchExample/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Examples/AdobeBranchExample/AdobeBranchExample/AppDelegate.m
+++ b/Examples/AdobeBranchExample/AdobeBranchExample/AppDelegate.m
@@ -46,7 +46,7 @@
     [ACPCore start:nil];
     
     // Disable event sharing
-    //[AdobeBranchExtension configureEventTypes:nil andEventSources:nil];
+    [AdobeBranchExtension configureEventTypes:nil andEventSources:nil];
     
     [AdobeBranchExtension initSessionWithLaunchOptions:launchOptions andRegisterDeepLinkHandler:^(NSDictionary * _Nullable params, NSError * _Nullable error) {
         if (!error && params && [params[@"+clicked_branch_link"] boolValue]) {

--- a/Examples/AdobeBranchExample/AdobeBranchExample/AppDelegate.m
+++ b/Examples/AdobeBranchExample/AdobeBranchExample/AppDelegate.m
@@ -45,6 +45,9 @@
     }
     [ACPCore start:nil];
     
+    // Disable event sharing
+    [AdobeBranchExtension configureEventTypes:@[] andEventSources:@[]];
+    
     [AdobeBranchExtension initSessionWithLaunchOptions:launchOptions andRegisterDeepLinkHandler:^(NSDictionary * _Nullable params, NSError * _Nullable error) {
         if (!error && params && [params[@"+clicked_branch_link"] boolValue]) {
 

--- a/Examples/AdobeBranchExample/AdobeBranchExample/AppDelegate.m
+++ b/Examples/AdobeBranchExample/AdobeBranchExample/AppDelegate.m
@@ -46,7 +46,7 @@
     [ACPCore start:nil];
     
     // Disable event sharing
-    [AdobeBranchExtension configureEventTypes:nil andEventSources:nil];
+    //[AdobeBranchExtension configureEventTypes:nil andEventSources:nil];
     
     [AdobeBranchExtension initSessionWithLaunchOptions:launchOptions andRegisterDeepLinkHandler:^(NSDictionary * _Nullable params, NSError * _Nullable error) {
         if (!error && params && [params[@"+clicked_branch_link"] boolValue]) {

--- a/Examples/AdobeBranchExample/AdobeBranchExample/AppDelegate.m
+++ b/Examples/AdobeBranchExample/AdobeBranchExample/AppDelegate.m
@@ -46,7 +46,7 @@
     [ACPCore start:nil];
     
     // Disable event sharing
-    [AdobeBranchExtension configureEventTypes:@[] andEventSources:@[]];
+    //[AdobeBranchExtension configureEventTypes:nil andEventSources:nil];
     
     [AdobeBranchExtension initSessionWithLaunchOptions:launchOptions andRegisterDeepLinkHandler:^(NSDictionary * _Nullable params, NSError * _Nullable error) {
         if (!error && params && [params[@"+clicked_branch_link"] boolValue]) {

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Here's an example of tracking app state via Adobe Launch:
         @"currency":    @"USD"
     }];
 
-You can also customize which event types and sources are shared with Branch.  Providing empty lists, disables sharing.
+You can also customize which event types and sources are shared with Branch.  Providing empty lists disables sharing.
 
     [AdobeBranchExtension configureEventTypes:@[ @"com.adobe.eventType.generic.track" ] andEventSources:@[ @"com.adobe.eventSource.requestContent" ];
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ Here's an example of tracking app state via Adobe Launch:
         @"currency":    @"USD"
     }];
 
+You can also customize which event types and sources are shared with Branch.  Providing empty lists, disables sharing.
+
+    [AdobeBranchExtension configureEventTypes:@[ @"com.adobe.eventType.generic.track" ] andEventSources:@[ @"com.adobe.eventSource.requestContent" ];
+
 ## License
 
 AdobeBranchExtension is available under the MIT license. See the LICENSE file for more info.


### PR DESCRIPTION
Add a public API to customize event sharing.  This feature can be tested by using the sample app with a break point on the callback.

