### PR TITLE
Support excluding events by names from AdobeBranchExtension

### DIFF
--- a/AdobeBranchExtension.podspec
+++ b/AdobeBranchExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AdobeBranchExtension"
-  s.version          = "1.3.2"
+  s.version          = "1.3.3"
   s.summary          = "The Branch extension for Adobe Cloud Platform on iOS."
 
   s.description      = <<-DESC

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.h
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.h
@@ -23,6 +23,11 @@ FOUNDATION_EXPORT NSString*const ABEBranchEventType;
 /// Branch extension event source
 FOUNDATION_EXPORT NSString*const ABEBranchEventSource;
 
+/// Branch extension error code
+typedef NS_ENUM(NSInteger, ABEBranchErrorCode) {
+    ABEBranchConflictConfiguration  = 2000,
+};
+
 /**
  This is the class defines the root Adobe / Branch integration for deep linking and events.
  */
@@ -36,9 +41,9 @@ FOUNDATION_EXPORT NSString*const ABEBranchEventSource;
 
 + (void)configureEventTypes:(nullable NSArray<NSString *> *)eventTypes andEventSources:(nullable NSArray<NSString *> *)eventSources;
 
-+ (void)configureEventExclusionList:(nullable NSArray<NSString *> *)eventNames;
++ (BOOL)configureEventExclusionList:(nullable NSArray<NSString *> *)eventNames error:(NSError * __autoreleasing *)configError;
 
-+ (void)configureEventAllowList:(nullable NSArray<NSString *> *)eventNames;
++ (BOOL)configureEventAllowList:(nullable NSArray<NSString *> *)eventNames error:(NSError * __autoreleasing *)configError;
 
 - (void)handleEvent:(ACPExtensionEvent*)event;
 

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.h
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.h
@@ -38,6 +38,8 @@ FOUNDATION_EXPORT NSString*const ABEBranchEventSource;
 
 + (void)configureEventExclusionList:(nullable NSArray<NSString *> *)eventNames;
 
++ (void)configureEventAllowList:(nullable NSArray<NSString *> *)eventNames;
+
 - (void)handleEvent:(ACPExtensionEvent*)event;
 
 @end

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.h
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.h
@@ -36,6 +36,8 @@ FOUNDATION_EXPORT NSString*const ABEBranchEventSource;
 
 + (void)configureEventTypes:(nullable NSArray<NSString *> *)eventTypes andEventSources:(nullable NSArray<NSString *> *)eventSources;
 
++ (void)configureEventExclusionList:(nullable NSArray<NSString *> *)eventNames;
+
 - (void)handleEvent:(ACPExtensionEvent*)event;
 
 @end

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
@@ -93,6 +93,12 @@ NSString *const ABEAdobeAnalyticsExtension = @"com.adobe.module.analytics";
     }
 }
 
++ (void)configureEventExclusionList:(nullable NSArray<NSString *> *)eventNames {
+    if (eventNames) {
+        [AdobeBranchExtensionConfig instance].excludedEventNames = eventNames;
+    }
+}
+
 - (instancetype)init {
     self = [super init];
     if (!self) return self;
@@ -221,6 +227,7 @@ NSMutableDictionary *BNCStringDictionaryWithDictionary(NSDictionary*dictionary_)
     NSString *eventName = eventData[@"action"];
     if (!eventName.length) eventName = eventData[@"state"];
     if (!eventName.length) return;
+    if ([[AdobeBranchExtensionConfig instance].excludedEventNames containsObject: eventName]) return;
     NSDictionary *content = [eventData objectForKey:@"contextdata"];
     BranchEvent *branchEvent = [self.class branchEventFromAdobeEventName:eventName dictionary:content];
     [branchEvent logEvent];

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
@@ -98,7 +98,7 @@ NSString *const ABEAdobeAnalyticsExtension = @"com.adobe.module.analytics";
         // If already configured allowList
         if ([AdobeBranchExtensionConfig instance].allowList.count != 0) {
             @throw [NSException
-                        exceptionWithName:@"InconsistentParameter"
+                        exceptionWithName:@"ConflictConfiguration"
                         reason:@"Already configured allowList for AdobeBranchExtensionConfig"
                         userInfo:nil];
         } else {
@@ -112,7 +112,7 @@ NSString *const ABEAdobeAnalyticsExtension = @"com.adobe.module.analytics";
         // If already configured allowList
         if ([AdobeBranchExtensionConfig instance].exclusionList.count != 0) {
             @throw [NSException
-                        exceptionWithName:@"InconsistentParameter"
+                        exceptionWithName:@"ConflictConfiguration"
                         reason:@"Already configured exclusionList for AdobeBranchExtensionConfig"
                         userInfo:nil];
         } else {
@@ -257,7 +257,7 @@ NSMutableDictionary *BNCStringDictionaryWithDictionary(NSDictionary*dictionary_)
 
 - (BOOL)isValidEventForBranch:(NSString*)eventName {
     if ([AdobeBranchExtensionConfig instance].exclusionList.count == 0 && [AdobeBranchExtensionConfig instance].allowList.count == 0) {
-        return YES;
+        return NO;
     } else if ([AdobeBranchExtensionConfig instance].allowList.count != 0 && [[AdobeBranchExtensionConfig instance].allowList containsObject: eventName]) {
         return YES;
     } else if ([AdobeBranchExtensionConfig instance].exclusionList.count != 0 && [[AdobeBranchExtensionConfig instance].exclusionList containsObject: eventName]) {

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
@@ -260,8 +260,8 @@ NSMutableDictionary *BNCStringDictionaryWithDictionary(NSDictionary*dictionary_)
         return YES;
     } else if ([AdobeBranchExtensionConfig instance].allowList.count != 0 && [[AdobeBranchExtensionConfig instance].allowList containsObject: eventName]) {
         return YES;
-    } else if ([AdobeBranchExtensionConfig instance].exclusionList.count != 0 && [[AdobeBranchExtensionConfig instance].exclusionList containsObject: eventName]) {
-        return NO;
+    } else if ([AdobeBranchExtensionConfig instance].exclusionList.count != 0 && ![[AdobeBranchExtensionConfig instance].exclusionList containsObject: eventName]) {
+        return YES;
     }
 
     return NO;

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
@@ -257,7 +257,7 @@ NSMutableDictionary *BNCStringDictionaryWithDictionary(NSDictionary*dictionary_)
 
 - (BOOL)isValidEventForBranch:(NSString*)eventName {
     if ([AdobeBranchExtensionConfig instance].exclusionList.count == 0 && [AdobeBranchExtensionConfig instance].allowList.count == 0) {
-        return NO;
+        return YES;
     } else if ([AdobeBranchExtensionConfig instance].allowList.count != 0 && [[AdobeBranchExtensionConfig instance].allowList containsObject: eventName]) {
         return YES;
     } else if ([AdobeBranchExtensionConfig instance].exclusionList.count != 0 && [[AdobeBranchExtensionConfig instance].exclusionList containsObject: eventName]) {

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
@@ -16,6 +16,9 @@
 NSString*const ABEBranchEventType               = @"com.branch.eventType";
 NSString*const ABEBranchEventSource             = @"com.branch.eventSource";
 
+// Adobe Launch Branch extension error domain
+NSString*const AdobeBranchExtensionErrorDomain  = @"io.branch.adobe_launch_extension.error";
+
 // 1. events of this type and source
 NSString *const ABEAdobeHubEventType = @"com.adobe.eventType.hub";
 NSString *const ABEAdobeSharedStateEventSource = @"com.adobe.eventSource.sharedState";
@@ -93,32 +96,32 @@ NSString *const ABEAdobeAnalyticsExtension = @"com.adobe.module.analytics";
     }
 }
 
-+ (void)configureEventExclusionList:(nullable NSArray<NSString *> *)eventNames {
++ (BOOL)configureEventExclusionList:(nullable NSArray<NSString *> *)eventNames error:(NSError * __autoreleasing *)configError {
     if (eventNames) {
         // If already configured allowList
         if ([AdobeBranchExtensionConfig instance].allowList.count != 0) {
-            @throw [NSException
-                        exceptionWithName:@"ConflictConfiguration"
-                        reason:@"Already configured allowList for AdobeBranchExtensionConfig"
-                        userInfo:nil];
+            *configError = [NSError errorWithDomain:AdobeBranchExtensionErrorDomain code:ABEBranchConflictConfiguration userInfo:@{NSLocalizedFailureReasonErrorKey: @"Already configured allowList for AdobeBranchExtensionConfig"}];
+            BNCLogError([NSString stringWithFormat:@"AdobeBranchExtensionConfig error: %@.", *configError]);
+            return NO;
         } else {
             [AdobeBranchExtensionConfig instance].exclusionList = eventNames;
         }
     }
+    return YES;
 }
 
-+ (void)configureEventAllowList:(nullable NSArray<NSString *> *)eventNames {
++ (BOOL)configureEventAllowList:(nullable NSArray<NSString *> *)eventNames error:(NSError * __autoreleasing *)configError {
     if (eventNames) {
         // If already configured allowList
         if ([AdobeBranchExtensionConfig instance].exclusionList.count != 0) {
-            @throw [NSException
-                        exceptionWithName:@"ConflictConfiguration"
-                        reason:@"Already configured exclusionList for AdobeBranchExtensionConfig"
-                        userInfo:nil];
+            *configError = [NSError errorWithDomain:AdobeBranchExtensionErrorDomain code:ABEBranchConflictConfiguration userInfo:@{NSLocalizedFailureReasonErrorKey: @"Already configured exclusionList for AdobeBranchExtensionConfig"}];
+            BNCLogError([NSString stringWithFormat:@"AdobeBranchExtensionConfig error: %@.", *configError]);
+            return NO;
         } else {
             [AdobeBranchExtensionConfig instance].allowList = eventNames;
         }
     }
+    return YES;
 }
 
 - (instancetype)init {

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
@@ -95,11 +95,11 @@ NSString *const ABEAdobeAnalyticsExtension = @"com.adobe.module.analytics";
 
 + (void)configureEventExclusionList:(nullable NSArray<NSString *> *)eventNames {
     if (eventNames) {
-        // If already defined allowList
+        // If already configured allowList
         if ([AdobeBranchExtensionConfig instance].allowList.count != 0) {
             @throw [NSException
                         exceptionWithName:@"InconsistentParameter"
-                        reason:@"Already defined allowList for AdobeBranchExtensionConfig"
+                        reason:@"Already configured allowList for AdobeBranchExtensionConfig"
                         userInfo:nil];
         } else {
             [AdobeBranchExtensionConfig instance].exclusionList = eventNames;
@@ -109,11 +109,11 @@ NSString *const ABEAdobeAnalyticsExtension = @"com.adobe.module.analytics";
 
 + (void)configureEventAllowList:(nullable NSArray<NSString *> *)eventNames {
     if (eventNames) {
-        // If already defined allowList
+        // If already configured allowList
         if ([AdobeBranchExtensionConfig instance].exclusionList.count != 0) {
             @throw [NSException
                         exceptionWithName:@"InconsistentParameter"
-                        reason:@"Already defined exclusionList for AdobeBranchExtensionConfig"
+                        reason:@"Already configured exclusionList for AdobeBranchExtensionConfig"
                         userInfo:nil];
         } else {
             [AdobeBranchExtensionConfig instance].allowList = eventNames;

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionConfig.h
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionConfig.h
@@ -12,7 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface AdobeBranchExtensionConfig : NSObject
 @property (nonatomic, strong, readwrite) NSArray<NSString *> *eventTypes;
 @property (nonatomic, strong, readwrite) NSArray<NSString *> *eventSources;
-@property (nonatomic, strong, readwrite) NSArray<NSString *> *excludedEventNames;
+@property (nonatomic, strong, readwrite) NSArray<NSString *> *exclusionList;
+@property (nonatomic, strong, readwrite) NSArray<NSString *> *allowList;
 
 + (AdobeBranchExtensionConfig *)instance;
 

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionConfig.h
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionConfig.h
@@ -12,6 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface AdobeBranchExtensionConfig : NSObject
 @property (nonatomic, strong, readwrite) NSArray<NSString *> *eventTypes;
 @property (nonatomic, strong, readwrite) NSArray<NSString *> *eventSources;
+@property (nonatomic, strong, readwrite) NSArray<NSString *> *excludedEventNames;
 
 + (AdobeBranchExtensionConfig *)instance;
 

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionConfig.m
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionConfig.m
@@ -24,6 +24,7 @@
         // default event type and source to track, client can override
         self.eventTypes = @[ @"com.adobe.eventType.generic.track" ];
         self.eventSources = @[ @"com.adobe.eventSource.requestContent" ];
+        self.excludedEventNames = [NSArray new];
     }
     return self;
 }

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionConfig.m
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionConfig.m
@@ -24,7 +24,8 @@
         // default event type and source to track, client can override
         self.eventTypes = @[ @"com.adobe.eventType.generic.track" ];
         self.eventSources = @[ @"com.adobe.eventSource.requestContent" ];
-        self.excludedEventNames = [NSArray new];
+        self.exclusionList = [NSArray new];
+        self.allowList = [NSArray new];
     }
     return self;
 }

--- a/Examples/AdobeBranchExample/AdobeBranchExample.xcodeproj/project.pbxproj
+++ b/Examples/AdobeBranchExample/AdobeBranchExample.xcodeproj/project.pbxproj
@@ -3,11 +3,11 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1C32DC67D5A305502173C088 /* libPods-AdobeBranchExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FFBBC7A62D08C7161630F13C /* libPods-AdobeBranchExample.a */; };
+		3228F43713344BCB4F316B9A /* Pods_AdobeBranchExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B0EA9C30991048D8A522C726 /* Pods_AdobeBranchExample.framework */; };
 		4D16DBA421AF037F00E362A2 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4D16DBA321AF037F00E362A2 /* Launch Screen.storyboard */; };
 		4D16DBA721AF5B6300E362A2 /* TextViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D16DBA621AF5B6300E362A2 /* TextViewController.m */; };
 		4DE097FD219CEABE008AC401 /* Products.json in Resources */ = {isa = PBXBuildFile; fileRef = 4DE097FC219CEABE008AC401 /* Products.json */; };
@@ -60,9 +60,9 @@
 		ACF671D721534E4F00CDC900 /* ACPCore_iOS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ACPCore_iOS.framework; path = Pods/ACPCoreBeta/ACPCore_iOS.framework; sourceTree = "<group>"; };
 		ACF671D821534E4F00CDC900 /* ACPSignal_iOS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ACPSignal_iOS.framework; path = Pods/ACPCoreBeta/ACPSignal_iOS.framework; sourceTree = "<group>"; };
 		ACF671D921534E4F00CDC900 /* ACPLifecycle_iOS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ACPLifecycle_iOS.framework; path = Pods/ACPCoreBeta/ACPLifecycle_iOS.framework; sourceTree = "<group>"; };
+		B0EA9C30991048D8A522C726 /* Pods_AdobeBranchExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AdobeBranchExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8688AE753553EE80251EE11 /* Pods-adobe-branch-example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-adobe-branch-example.release.xcconfig"; path = "Pods/Target Support Files/Pods-adobe-branch-example/Pods-adobe-branch-example.release.xcconfig"; sourceTree = "<group>"; };
 		FD81B1B19DDC0E314016948F /* Pods-adobe-branch-example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-adobe-branch-example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-adobe-branch-example/Pods-adobe-branch-example.debug.xcconfig"; sourceTree = "<group>"; };
-		FFBBC7A62D08C7161630F13C /* libPods-AdobeBranchExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-AdobeBranchExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -76,7 +76,7 @@
 				ACAE812F2122644F0049505B /* libz.tbd in Frameworks */,
 				ACAE812D212264480049505B /* libstdc++.tbd in Frameworks */,
 				ACAE812B2122643A0049505B /* libsqlite3.tbd in Frameworks */,
-				1C32DC67D5A305502173C088 /* libPods-AdobeBranchExample.a in Frameworks */,
+				3228F43713344BCB4F316B9A /* Pods_AdobeBranchExample.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -152,7 +152,7 @@
 				ACAE812C212264480049505B /* libstdc++.tbd */,
 				ACAE812A2122643A0049505B /* libsqlite3.tbd */,
 				2E21CAD8A1C925AAF24986BC /* libPods-adobe-branch-example.a */,
-				FFBBC7A62D08C7161630F13C /* libPods-AdobeBranchExample.a */,
+				B0EA9C30991048D8A522C726 /* Pods_AdobeBranchExample.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -168,6 +168,7 @@
 				ACAE8100212263F30049505B /* Sources */,
 				ACAE8101212263F30049505B /* Frameworks */,
 				ACAE8102212263F30049505B /* Resources */,
+				7312F033701CC016ACD11288 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -185,7 +186,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = ABE;
-				LastUpgradeCheck = 0940;
+				LastUpgradeCheck = 1240;
 				ORGANIZATIONNAME = "Branch Metrics";
 				TargetAttributes = {
 					ACAE8103212263F30049505B = {
@@ -231,6 +232,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		7312F033701CC016ACD11288 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-AdobeBranchExample/Pods-AdobeBranchExample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-AdobeBranchExample/Pods-AdobeBranchExample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AdobeBranchExample/Pods-AdobeBranchExample-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		80D4725CEFFA1CA56A0BB493 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -305,6 +323,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -330,7 +349,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -363,6 +382,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -382,7 +402,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
@@ -399,7 +419,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = R63EM248DP;
 				INFOPLIST_FILE = "$(SRCROOT)/AdobeBranchExample/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -421,7 +441,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = R63EM248DP;
 				INFOPLIST_FILE = "$(SRCROOT)/AdobeBranchExample/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Examples/AdobeBranchExample/AdobeBranchExample.xcworkspace/xcshareddata/xcschemes/AdobeBranchExample.xcscheme
+++ b/Examples/AdobeBranchExample/AdobeBranchExample.xcworkspace/xcshareddata/xcschemes/AdobeBranchExample.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1120"
+   LastUpgradeVersion = "1240"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Examples/AdobeBranchExample/AdobeBranchExample/AppDelegate.m
+++ b/Examples/AdobeBranchExample/AdobeBranchExample/AppDelegate.m
@@ -48,9 +48,17 @@
     
     // NOTE! following code will enable you to configure exclusion list or allow list, but you can't define both! If you don't configure any, all events will send to Branch which is not ideal!
     // Define the exclusion list of the events names
-//    [AdobeBranchExtension configureEventExclusionList:@[@"VIEW"]];
+//    if ([AdobeBranchExtension configureEventExclusionList:@[@"VIEW"] error:&error]) {
+//        NSLog(@"AdobeBranchExtension AllowList configured");
+//    } else {
+//        NSLog(@"%@", error);
+//    }
     // Define the allow list of the events names
-    [AdobeBranchExtension configureEventAllowList:@[@"VIEW"]];
+    if ([AdobeBranchExtension configureEventAllowList:@[@"VIEW"] error:&error]) {
+        NSLog(@"AdobeBranchExtension AllowList configured");
+    } else {
+        NSLog(@"%@", error);
+    }
     // register AdobeBranchExtension
     if ([ACPCore registerExtension:[AdobeBranchExtension class] error:&error]) {
         NSLog(@"AdobeBranchExtension Registered");

--- a/Examples/AdobeBranchExample/AdobeBranchExample/AppDelegate.m
+++ b/Examples/AdobeBranchExample/AdobeBranchExample/AppDelegate.m
@@ -46,8 +46,11 @@
     [ACPIdentity registerExtension];
     [ACPLifecycle registerExtension];
     
+    // NOTE! following code will enable you to configure exclusion list or allow list, but you can't define both! If you don't configure any, all events will send to Branch which is not ideal!
     // Define the exclusion list of the events names
-    [AdobeBranchExtension configureEventExclusionList:@[@"VIEW"]];
+//    [AdobeBranchExtension configureEventExclusionList:@[@"VIEW"]];
+    // Define the allow list of the events names
+    [AdobeBranchExtension configureEventAllowList:@[@"VIEW"]];
     // register AdobeBranchExtension
     if ([ACPCore registerExtension:[AdobeBranchExtension class] error:&error]) {
         NSLog(@"AdobeBranchExtension Registered");

--- a/Examples/AdobeBranchExample/AdobeBranchExample/AppDelegate.m
+++ b/Examples/AdobeBranchExample/AdobeBranchExample/AppDelegate.m
@@ -10,13 +10,12 @@
 
 #import "ACPCore.h"
 #import "ACPAnalytics.h"
-#import "ACPIdentity.h"
-#import "ACPLifecycle.h"
+#import <ACPCore/ACPIdentity.h>
+#import <ACPCore/ACPLifecycle.h>
 #import "ACPSignal.h"
 #import "ACPUserProfile.h"
 
 #import "ProductViewController.h"
-
 #import "AdobeBranchExtension.h"
 
 @interface AppDelegate ()
@@ -47,6 +46,8 @@
     [ACPIdentity registerExtension];
     [ACPLifecycle registerExtension];
     
+    // Define the exclusion list of the events names
+    [AdobeBranchExtension configureEventExclusionList:@[@"VIEW"]];
     // register AdobeBranchExtension
     if ([ACPCore registerExtension:[AdobeBranchExtension class] error:&error]) {
         NSLog(@"AdobeBranchExtension Registered");

--- a/Examples/AdobeBranchExample/Podfile
+++ b/Examples/AdobeBranchExample/Podfile
@@ -1,10 +1,9 @@
-source 'https://github.com/CocoaPods/Specs.git'
-platform :ios, '10.0'
-
 target 'AdobeBranchExample' do
-  pod 'ACPCore', '~> 2.0'
-  pod 'ACPAnalytics', '~> 2.0'
-  pod 'ACPUserProfile', '~> 2.0'
+  use_frameworks!
+  pod 'Branch'
+  pod 'ACPCore'
+  pod 'ACPAnalytics'
+  pod 'ACPUserProfile'
 
   pod 'AdobeBranchExtension', :path => '../../'
 end


### PR DESCRIPTION
**Changes:**
- Add a new method + (void)configureEventExclusionList:(nullable NSArray<NSString *> *)eventNames; from AdobeBranchExtension to exclude certain events to send to Branch
- Add a new property excludedEventNames from AdobeBranchExtensionConfig to retain the events names for exclusion
- Update the AppDelegate.m file to provide an example about how to use the configureEventExclusionList method
- Update the project file and Podfile to make it work

Note: This might not be an ideal solution for all customers but currently one of customer is tracking pageView event from iOS and Analytics Track event from Android to cause unnecessary AWS cost from Branch. It's good if we can provide a quick workaround for them to reduce the amount of events they are tracking.
