### PR TITLE
SDK-1625 corresponding podspec update to pick up fixed iOS SDK

### DIFF
--- a/AdobeBranchExtension.podspec
+++ b/AdobeBranchExtension.podspec
@@ -24,5 +24,5 @@ Pod::Spec.new do |s|
   s.source_files     = 'AdobeBranchExtension/Classes/**/*'
 
   s.dependency 'ACPCore',   '~> 2.9.6'
-  s.dependency 'Branch',    '~> 1.43.1'
+  s.dependency 'Branch',    '~> 1.43.2'
 end

--- a/AdobeBranchExtension.podspec
+++ b/AdobeBranchExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AdobeBranchExtension"
-  s.version          = "1.3.5"
+  s.version          = "1.3.6"
   s.summary          = "The Branch extension for Adobe Cloud Platform on iOS."
 
   s.description      = <<-DESC
@@ -23,6 +23,6 @@ Pod::Spec.new do |s|
 
   s.source_files     = 'AdobeBranchExtension/Classes/**/*'
 
-  s.dependency 'ACPCore',   '~> 2.9'
-  s.dependency 'Branch',    '~> 1.41.0'
+  s.dependency 'ACPCore',   '~> 2.9.6'
+  s.dependency 'Branch',    '~> 1.43.1'
 end


### PR DESCRIPTION
Update dependencies and update version.

This picks up a version of the Branch SDK that fixes a rare threading issue. Note this should not ship until the corresponding iOS SDK ships.