### PR TITLE
[SDK-1987] Update AEP SDK's to 4.0.0

### DIFF
--- a/AdobeBranchExtension.podspec
+++ b/AdobeBranchExtension.podspec
@@ -23,9 +23,10 @@ Pod::Spec.new do |s|
 
   s.source_files     = 'AdobeBranchExtension/Classes/**/*'
 
-  s.dependency 'AEPCore',      '~> 3.9.0'
-  s.dependency 'AEPLifecycle', '~> 3.9.0'
-  s.dependency 'AEPIdentity',  '~> 3.9.0'
-  s.dependency 'AEPSignal',    '~> 3.9.0'
-  s.dependency 'BranchSDK',    '~> 2.1.2'
+  s.dependency 'AEPCore',        '~> 4.0.0'
+  s.dependency 'AEPLifecycle',   '~> 4.0.0'
+  s.dependency 'AEPIdentity',    '~> 4.0.0'
+  s.dependency 'AEPSignal',      '~> 4.0.0'
+  s.dependency 'AEPRulesEngine', '~> 4.0.0'
+  s.dependency 'BranchSDK',      '~> 2.1.2'
 end

--- a/AdobeBranchExtension.podspec
+++ b/AdobeBranchExtension.podspec
@@ -27,6 +27,5 @@ Pod::Spec.new do |s|
   s.dependency 'AEPLifecycle',   '~> 4.0.0'
   s.dependency 'AEPIdentity',    '~> 4.0.0'
   s.dependency 'AEPSignal',      '~> 4.0.0'
-  s.dependency 'AEPRulesEngine', '~> 4.0.0'
   s.dependency 'BranchSDK',      '~> 2.1.2'
 end

--- a/AdobeBranchExtension.podspec
+++ b/AdobeBranchExtension.podspec
@@ -15,7 +15,6 @@ Pod::Spec.new do |s|
   s.author           = { "Branch Metrics" => "support@branch.io" }
   s.compiler_flags   = %[-DADOBE_BRANCH_VERSION=@\\"#{s.version}\\"]
   s.source           = { :git => "https://github.com/BranchMetrics/AdobeBranchExtension-iOS.git", :tag => s.version.to_s }
-  s.social_media_url = 'https://twitter.com/branchmetrics'
 
   s.platform         = :ios, '11.0'
   s.requires_arc     = true


### PR DESCRIPTION
## Reference
SDK-1987 -- Update AEP SDK's to 4.0.0

## Summary
Version bump for the AEP SDK's. No code changes required because the main reason for the AEP SDK's major version bump is updating the minimum target to iOS 11, which we already had as our minimum.

## Motivation
Release with the latest major Adobe SDK's versions.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Run the sample app and confirm everything works correctly.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
