### PR TITLE
[SDK-1864] Updated dependency SDKs and platform minimum

### DIFF
--- a/AdobeBranchExtension.podspec
+++ b/AdobeBranchExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AdobeBranchExtension"
-  s.version          = "2.0.0"
+  s.version          = "3.0.0"
   s.summary          = "The Branch extension for Adobe Cloud Platform on iOS."
 
   s.description      = <<-DESC
@@ -16,15 +16,15 @@ Pod::Spec.new do |s|
   s.compiler_flags   = %[-DADOBE_BRANCH_VERSION=@\\"#{s.version}\\"]
   s.source           = { :git => "https://github.com/BranchMetrics/AdobeBranchExtension-iOS.git", :tag => s.version.to_s }
 
-  s.platform         = :ios, '11.0'
+  s.platform         = :ios, '12.0'
   s.requires_arc     = true
   s.static_framework = true
 
   s.source_files     = 'AdobeBranchExtension/Classes/**/*'
 
-  s.dependency 'AEPCore',        '~> 4.0.0'
-  s.dependency 'AEPLifecycle',   '~> 4.0.0'
-  s.dependency 'AEPIdentity',    '~> 4.0.0'
-  s.dependency 'AEPSignal',      '~> 4.0.0'
-  s.dependency 'BranchSDK',      '~> 2.1.2'
+  s.dependency 'AEPCore',        '~> 4.2.0'
+  s.dependency 'AEPLifecycle',   '~> 4.2.0'
+  s.dependency 'AEPIdentity',    '~> 4.2.0'
+  s.dependency 'AEPSignal',      '~> 4.2.0'
+  s.dependency 'BranchSDK',      '~> 3.0.0'
 end


### PR DESCRIPTION
## Reference
SDK-1864 -- Updated dependency SDKs and platform minimum

## Summary
Updated the Branch SDK to 3.0.0 and the AEP SDKs to 4.2.0. This also required raising the minimum iOS version from 11.0 to 12.0. 

## Motivation
To keep the plugin up to date with the native SDK's features.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.