### PR TITLE
[INTENG-19921] Fixed custom data not being properly included

### DIFF
--- a/AdobeBranchExtension.podspec
+++ b/AdobeBranchExtension.podspec
@@ -26,5 +26,5 @@ Pod::Spec.new do |s|
   s.dependency 'AEPLifecycle',   '~> 4.2.0'
   s.dependency 'AEPIdentity',    '~> 4.2.0'
   s.dependency 'AEPSignal',      '~> 4.2.0'
-  s.dependency 'BranchSDK',      '~> 3.0.1'
+  s.dependency 'BranchSDK',      '~> 3.2.0'
 end

--- a/AdobeBranchExtension.podspec
+++ b/AdobeBranchExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AdobeBranchExtension"
-  s.version          = "3.0.0"
+  s.version          = "3.1.0"
   s.summary          = "The Branch extension for Adobe Cloud Platform on iOS."
 
   s.description      = <<-DESC

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
@@ -198,7 +198,7 @@ NSMutableDictionary *BNCStringDictionaryWithDictionary(NSDictionary*dictionary_)
     for (id<NSObject> key in dictionary_.keyEnumerator) {
         NSString *stringValue = BNCStringWithObject(dictionary_[key]);
         NSString *stringKey = BNCStringWithObject(key);
-        if (stringKey.length && stringValue.length) dictionary[stringKey] = stringValue;
+        if (stringKey.length && stringValue != nil) dictionary[stringKey] = stringValue;
     }
     return dictionary;
 }

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
@@ -283,16 +283,13 @@ NSDictionary* getContentFromEvent(AEPEvent *event) {
     NSArray *parameters = [hitUrl componentsSeparatedByString:@"&"];
     NSMutableDictionary *content = [[NSMutableDictionary alloc] init];
     
-    NSArray *keys = @[@"category", @"currency", @"name", @"revenue", @"shipping", @"tax", @"coupon" ,@"sku", @"timestamp", @"transaction_id", @"affiliation", @"title", @"description", @"query"];
-    
     for (NSString *param in parameters) {
-        for (NSString *key in keys) {
-            if ([param containsString:[NSString stringWithFormat:@"%@=", key]]) {
-                NSString *value = [[param componentsSeparatedByString:@"="] lastObject];
-                value = [value stringByRemovingPercentEncoding];
-                [content setObject:value forKey:key];
-                break;
-            }
+        NSArray *keyValue = [param componentsSeparatedByString:@"="];
+        if (keyValue.count == 2) {
+            NSString *key = keyValue[0];
+            NSString *value = keyValue[1];
+            value = [value stringByRemovingPercentEncoding];
+            [content setObject:value forKey:key];
         }
     }
     

--- a/Examples/AdobeBranchExample/AdobeBranchExample/ProductListViewController.m
+++ b/Examples/AdobeBranchExample/AdobeBranchExample/ProductListViewController.m
@@ -125,7 +125,7 @@
             @"category":        @"Apparel & Accessories",
             @"sku":             @"sku-bee-doo",
             @"adobeTestID" :    @"12345",
-            @"myCustomValue":    @"Glasses"
+            @"myCustomValue":   @"Glasses"
         }];
         break;
     }}

--- a/Examples/AdobeBranchExample/AdobeBranchExample/ProductListViewController.m
+++ b/Examples/AdobeBranchExample/AdobeBranchExample/ProductListViewController.m
@@ -124,6 +124,8 @@
             @"timestamp":       [NSDate date].description,
             @"category":        @"Apparel & Accessories",
             @"sku":             @"sku-bee-doo",
+            @"adobeTestID" :    @"12345",
+            @"myCustomValue":    @"Glasses"
         }];
         break;
     }}

--- a/Examples/AdobeBranchExample/AdobeBranchExample/ProductListViewController.m
+++ b/Examples/AdobeBranchExample/AdobeBranchExample/ProductListViewController.m
@@ -125,7 +125,8 @@
             @"category":        @"Apparel & Accessories",
             @"sku":             @"sku-bee-doo",
             @"adobeTestID" :    @"12345",
-            @"myCustomValue":   @"Glasses"
+            @"myCustomValue":   @"Glasses",
+            @"emptyValue":      @""
         }];
         break;
     }}


### PR DESCRIPTION
## Reference
[INTENG-19921] --- [Multiple | Adobe IOS SDK] Do not map the event custom data since 2.0.0 version

## Summary
When a tracking an action through the AEP SDK, only certain properties were being included in the respective BranchEvent. This update removes that and allows all data to be added to the Branch Event in the `custom_data` field. This matches up with the AdobeBranchExtension-Android behavior. 
This filtering was unnecessary because any data can be added to the custom_data and the `branchEventFromAdobeEventName()` method already maps known fields, like currency, revenue, etc, to the actual BranchEvent fields. 

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Branch events were not properly including all of the custom data from the Adobe events. So if a client tracked an event with `revenue` and `someCustomValue`, we would properly include `revenue` but drop `someCustomValue`.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Use the AEP SDK to track and event and observe all of the proper fields being passed along to the custom_data of the respective Branch Event.

```
[AEPMobileCore trackAction:eventName data: @{
    @"name":            @"Branch Sunglasses",
    @"revenue":         @"200.00",
    @"adobeTestID" :    @"12345",
    @"myCustomValue":    @"Glasses"
}];
```

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.


[INTENG-19921]: https://branch.atlassian.net/browse/INTENG-19921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ