### PR TITLE
[SDK-2449] Bumped SDK versions and updated logging code

### DIFF
--- a/AdobeBranchExtension.podspec
+++ b/AdobeBranchExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AdobeBranchExtension"
-  s.version          = "3.1.0"
+  s.version          = "3.2.0"
   s.summary          = "The Branch extension for Adobe Cloud Platform on iOS."
 
   s.description      = <<-DESC
@@ -22,9 +22,9 @@ Pod::Spec.new do |s|
 
   s.source_files     = 'AdobeBranchExtension/Classes/**/*'
 
-  s.dependency 'AEPCore',        '~> 4.2.0'
-  s.dependency 'AEPLifecycle',   '~> 4.2.0'
-  s.dependency 'AEPIdentity',    '~> 4.2.0'
-  s.dependency 'AEPSignal',      '~> 4.2.0'
-  s.dependency 'BranchSDK',      '~> 3.2.0'
+  s.dependency 'AEPCore',        '~> 5.1.0'
+  s.dependency 'AEPLifecycle',   '~> 5.1.0'
+  s.dependency 'AEPIdentity',    '~> 5.1.0'
+  s.dependency 'AEPSignal',      '~> 5.1.0'
+  s.dependency 'BranchSDK',      '~> 3.4.4'
 end

--- a/AdobeBranchExtension.podspec
+++ b/AdobeBranchExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AdobeBranchExtension"
-  s.version          = "3.2.0"
+  s.version          = "4.0.0"
   s.summary          = "The Branch extension for Adobe Cloud Platform on iOS."
 
   s.description      = <<-DESC

--- a/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
+++ b/AdobeBranchExtension/Classes/AdobeBranchExtensionClass.m
@@ -70,7 +70,7 @@ NSString *const ABEAdobeAnalyticsExtension = @"com.adobe.module.analytics";
 }
 
 - (void)onRegistered {
-    [[BranchLogger shared] logDebug:@"AdobeBranchExtension listener registered"];
+    [[BranchLogger shared] logDebug:@"AdobeBranchExtension listener registered" error:nil];
     
     [self deviceDataSharedState: NULL];
     
@@ -138,7 +138,7 @@ NSString *const ABEAdobeAnalyticsExtension = @"com.adobe.module.analytics";
         // If already configured allowList
         if ([AdobeBranchExtensionConfig instance].allowList.count != 0) {
             *configError = [NSError errorWithDomain:AdobeBranchExtensionErrorDomain code:ABEBranchConflictConfiguration userInfo:@{NSLocalizedFailureReasonErrorKey: @"Already configured allowList for AdobeBranchExtensionConfig"}];
-            [[BranchLogger shared] logWarning:[NSString stringWithFormat:@"AdobeBranchExtensionConfig error: %@.", *configError]];
+            [[BranchLogger shared] logWarning:[NSString stringWithFormat:@"AdobeBranchExtensionConfig error: %@.", *configError] error:*configError];
             return NO;
         } else {
             [AdobeBranchExtensionConfig instance].exclusionList = eventNames;
@@ -152,7 +152,7 @@ NSString *const ABEAdobeAnalyticsExtension = @"com.adobe.module.analytics";
         // If already configured allowList
         if ([AdobeBranchExtensionConfig instance].exclusionList.count != 0) {
             *configError = [NSError errorWithDomain:AdobeBranchExtensionErrorDomain code:ABEBranchConflictConfiguration userInfo:@{NSLocalizedFailureReasonErrorKey: @"Already configured exclusionList for AdobeBranchExtensionConfig"}];
-            [[BranchLogger shared] logWarning:[NSString stringWithFormat:@"AdobeBranchExtensionConfig error: %@.", *configError]];
+            [[BranchLogger shared] logWarning:[NSString stringWithFormat:@"AdobeBranchExtensionConfig error: %@.", *configError] error:*configError];
             return NO;
         } else {
             [AdobeBranchExtensionConfig instance].allowList = eventNames;
@@ -164,7 +164,7 @@ NSString *const ABEAdobeAnalyticsExtension = @"com.adobe.module.analytics";
 #pragma mark - Action Events
 
 - (void)handleEvent:(AEPEvent*)event {
-    [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"Handling Event: %@", event]];
+    [[BranchLogger shared] logDebug:[NSString stringWithFormat:@"Handling Event: %@", event] error:nil];
     
     if ([[AdobeBranchExtensionConfig instance].eventTypes containsObject:event.type] &&
         [[AdobeBranchExtensionConfig instance].eventSources containsObject:event.source]) {
@@ -333,11 +333,11 @@ NSString* getEventNameFromEvent(AEPEvent *event) {
     AEPSharedStateResult *configSharedState = [self.runtime getSharedStateWithExtensionName:eventToProcess.data[ABEAdobeEventDataKey_StateOwner] event:eventToProcess barrier:NO];
     
     if (!configSharedState.value) {
-        [[BranchLogger shared] logWarning: @"BranchSDK_ Could not process event, configuration shared state is pending"];
+        [[BranchLogger shared] logWarning: @"BranchSDK_ Could not process event, configuration shared state is pending" error:nil];
         return;
     }
     if (error) {
-        [[BranchLogger shared] logWarning: @"BranchSDK_ Could not process event, an error occured while retrieving configuration shared state"];
+        [[BranchLogger shared] logWarning: @"BranchSDK_ Could not process event, an error occured while retrieving configuration shared state" error:nil];
         return;
     }
     

--- a/Examples/AdobeBranchExample/AdobeBranchExample.xcodeproj/project.pbxproj
+++ b/Examples/AdobeBranchExample/AdobeBranchExample.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -25,6 +25,7 @@
 		ACAE81332122645B0049505B /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ACAE81322122645B0049505B /* UserNotifications.framework */; };
 		ACAE8135212264610049505B /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ACAE8134212264610049505B /* SystemConfiguration.framework */; };
 		C10F392A278E39AD00BF5D36 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C10F3929278E39AD00BF5D36 /* AdSupport.framework */; };
+		C12534432C18F6E4008A83C4 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = C12534422C18EE39008A83C4 /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -63,6 +64,7 @@
 		ACF671D921534E4F00CDC900 /* ACPLifecycle_iOS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ACPLifecycle_iOS.framework; path = Pods/ACPCoreBeta/ACPLifecycle_iOS.framework; sourceTree = "<group>"; };
 		B0EA9C30991048D8A522C726 /* Pods_AdobeBranchExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AdobeBranchExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C10F3929278E39AD00BF5D36 /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
+		C12534422C18EE39008A83C4 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		F8688AE753553EE80251EE11 /* Pods-adobe-branch-example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-adobe-branch-example.release.xcconfig"; path = "Pods/Target Support Files/Pods-adobe-branch-example/Pods-adobe-branch-example.release.xcconfig"; sourceTree = "<group>"; };
 		FD81B1B19DDC0E314016948F /* Pods-adobe-branch-example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-adobe-branch-example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-adobe-branch-example/Pods-adobe-branch-example.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -118,6 +120,7 @@
 		ACAE8106212263F30049505B /* AdobeBranchExample */ = {
 			isa = PBXGroup;
 			children = (
+				C12534422C18EE39008A83C4 /* PrivacyInfo.xcprivacy */,
 				ACF671CD2150B42800CDC900 /* AdobeBranchExample.entitlements */,
 				ACAE8107212263F30049505B /* AppDelegate.h */,
 				ACAE8108212263F30049505B /* AppDelegate.m */,
@@ -229,6 +232,7 @@
 				ACAE8111212263F40049505B /* Assets.xcassets in Resources */,
 				4DE097FD219CEABE008AC401 /* Products.json in Resources */,
 				4D16DBA421AF037F00E362A2 /* Launch Screen.storyboard in Resources */,
+				C12534432C18F6E4008A83C4 /* PrivacyInfo.xcprivacy in Resources */,
 				ACAE810F212263F40049505B /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Examples/AdobeBranchExample/AdobeBranchExample/AppDelegate.m
+++ b/Examples/AdobeBranchExample/AdobeBranchExample/AppDelegate.m
@@ -30,7 +30,7 @@
     // initialize Branch session, [AdobeBranchExtension initSessionWithLaunchOptions] is different from
     // [[Branch getInstance] initSessionWithLaunchOptions] in that it holds up initialization in order to collect
     // Adobe IDs and pass them to Branch as request metadata, see [AdobeBranchExtension delayInitSessionToCollectAdobeIDs]
-    [[Branch getInstance] enableLogging];
+    [Branch enableLogging];
     [AdobeBranchExtension initSessionWithLaunchOptions:launchOptions andRegisterDeepLinkHandler:^(NSDictionary * _Nullable params, NSError * _Nullable error) {
         if (!error && params && [params[@"+clicked_branch_link"] boolValue]) {
 

--- a/Examples/AdobeBranchExample/AdobeBranchExample/ProductListViewController.m
+++ b/Examples/AdobeBranchExample/AdobeBranchExample/ProductListViewController.m
@@ -109,6 +109,7 @@
         [linkProperties addControlParam:@"$desktop_url" withValue:  @"https://branch.io/branch/Glasses.html"];
         
         [branchUniversalObject getShortUrlWithLinkProperties:linkProperties andCallback:^(NSString *url, NSError *error) {
+            NSLog(@"Created Short Link: %@", url);
             [self showCreatedLink:url];
         }];
         break;


### PR DESCRIPTION
## Reference
SDK-2449 --  Bump to latest for privacy manifest

## Summary
Updated the AEP and Branch iOS SDK to the latest versions. To support this, some of the BranchLogger code has also been updated.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This update allows users to use the latest AEP SDKs which have important privacy manifest changes.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Run the testbed and ensure everything is still working properly. Create a privacy manifest and check that its properly being included.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
