### PR TITLE
[SDK-2473] Update SDK versions and fix runtime warning in example app

### DIFF
--- a/AdobeBranchExtension.podspec
+++ b/AdobeBranchExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AdobeBranchExtension"
-  s.version          = "4.0.0"
+  s.version          = "4.1.0"
   s.summary          = "The Branch extension for Adobe Cloud Platform on iOS."
 
   s.description      = <<-DESC
@@ -22,9 +22,9 @@ Pod::Spec.new do |s|
 
   s.source_files     = 'AdobeBranchExtension/Classes/**/*'
 
-  s.dependency 'AEPCore',        '~> 5.1.0'
-  s.dependency 'AEPLifecycle',   '~> 5.1.0'
-  s.dependency 'AEPIdentity',    '~> 5.1.0'
-  s.dependency 'AEPSignal',      '~> 5.1.0'
-  s.dependency 'BranchSDK',      '~> 3.4.4'
+  s.dependency 'AEPCore',        '~> 5.2.0'
+  s.dependency 'AEPLifecycle',   '~> 5.2.0'
+  s.dependency 'AEPIdentity',    '~> 5.2.0'
+  s.dependency 'AEPSignal',      '~> 5.2.0'
+  s.dependency 'BranchSDK',      '~> 3.6.0'
 end

--- a/Examples/AdobeBranchExample/AdobeBranchExample.xcodeproj/project.pbxproj
+++ b/Examples/AdobeBranchExample/AdobeBranchExample.xcodeproj/project.pbxproj
@@ -25,7 +25,6 @@
 		ACAE81332122645B0049505B /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ACAE81322122645B0049505B /* UserNotifications.framework */; };
 		ACAE8135212264610049505B /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ACAE8134212264610049505B /* SystemConfiguration.framework */; };
 		C10F392A278E39AD00BF5D36 /* AdSupport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C10F3929278E39AD00BF5D36 /* AdSupport.framework */; };
-		C12534432C18F6E4008A83C4 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = C12534422C18EE39008A83C4 /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -64,7 +63,6 @@
 		ACF671D921534E4F00CDC900 /* ACPLifecycle_iOS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ACPLifecycle_iOS.framework; path = Pods/ACPCoreBeta/ACPLifecycle_iOS.framework; sourceTree = "<group>"; };
 		B0EA9C30991048D8A522C726 /* Pods_AdobeBranchExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AdobeBranchExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C10F3929278E39AD00BF5D36 /* AdSupport.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AdSupport.framework; path = System/Library/Frameworks/AdSupport.framework; sourceTree = SDKROOT; };
-		C12534422C18EE39008A83C4 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		F8688AE753553EE80251EE11 /* Pods-adobe-branch-example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-adobe-branch-example.release.xcconfig"; path = "Pods/Target Support Files/Pods-adobe-branch-example/Pods-adobe-branch-example.release.xcconfig"; sourceTree = "<group>"; };
 		FD81B1B19DDC0E314016948F /* Pods-adobe-branch-example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-adobe-branch-example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-adobe-branch-example/Pods-adobe-branch-example.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -120,7 +118,6 @@
 		ACAE8106212263F30049505B /* AdobeBranchExample */ = {
 			isa = PBXGroup;
 			children = (
-				C12534422C18EE39008A83C4 /* PrivacyInfo.xcprivacy */,
 				ACF671CD2150B42800CDC900 /* AdobeBranchExample.entitlements */,
 				ACAE8107212263F30049505B /* AppDelegate.h */,
 				ACAE8108212263F30049505B /* AppDelegate.m */,
@@ -232,7 +229,6 @@
 				ACAE8111212263F40049505B /* Assets.xcassets in Resources */,
 				4DE097FD219CEABE008AC401 /* Products.json in Resources */,
 				4D16DBA421AF037F00E362A2 /* Launch Screen.storyboard in Resources */,
-				C12534432C18F6E4008A83C4 /* PrivacyInfo.xcprivacy in Resources */,
 				ACAE810F212263F40049505B /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Examples/AdobeBranchExample/AdobeBranchExample.xcworkspace/xcshareddata/xcschemes/AdobeBranchExample.xcscheme
+++ b/Examples/AdobeBranchExample/AdobeBranchExample.xcworkspace/xcshareddata/xcschemes/AdobeBranchExample.xcscheme
@@ -34,6 +34,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      disablePerformanceAntipatternChecker = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/scripts/version
+++ b/scripts/version
@@ -31,7 +31,7 @@ Options:
 USAGE
 }
 
-version=1.3.1
+version=4.1.0
 
 if (( $# == 0 )); then
     echo $version


### PR DESCRIPTION
## Reference
SDK-2473 -- iOS Adobe Branch Example app returns High Risk Error when the app is initially launched

## Summary
When our test app was launched, Xcode would show a runtime warning/hang risk in the BranchSDK's [Branch processNextQueueItem] method. Since the issue is only showing up in our sample app and not the SDK itself or other client apps, we can simply disable the Performance Anti-Pattern Checker so this will no longer show up.

This update also bumps the versions of the Adobe and Branch dependency SDKs as well as the AdobeBranchExtension itself's version.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
The app does not work as expected due to this error so it makes clients think our SDK currently has the problem and blocks the issue debugging. This change resolves that by preventing the warning from showing up.

## Type Of Change
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions
<!-- Testing instructions, example code snippets, etc -->
Run the Example app through Xcode with and without the change and observe the warning going away.

<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
