### PR TITLE
Updated Branch SDK to version 3.13.0

### DIFF
--- a/AdobeBranchExtension.podspec
+++ b/AdobeBranchExtension.podspec
@@ -26,5 +26,5 @@ Pod::Spec.new do |s|
   s.dependency 'AEPLifecycle',   '~> 5.1.0'
   s.dependency 'AEPIdentity',    '~> 5.1.0'
   s.dependency 'AEPSignal',      '~> 5.1.0'
-  s.dependency 'BranchSDK',      '~> 3.4.4'
+  s.dependency 'BranchSDK',      '~> 3.13.0'
 end


### PR DESCRIPTION
## Reference
SDK-EMT-23298 -- [Multiple] SDK Version Warning Message Vs. Some Actual SDKs Mismatch For Activation.

## Summary
Updated Native iOS Branch SDK to version 3.13.0 in order to improve its capabilities.

## Motivation
Customer using extension learned they could not utilize the Activation product without being on a newer version of the Native Branch SDKs.

## Type Of Change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Testing Instructions

1. Run the Example app and ensure organic open works properly.
2. Create a Branch Link using built in API
3. Open app Using Branch link and ensure read Branch link functions properly
4. Run Branch Event
5. Ensure all Branch functionality works properly.


<!-- Checklist -->
<!-- My code follows the style guidelines of this project -->
<!-- I have performed a self-review of my code -->
<!-- I have commented my code, particularly in hard-to-understand areas -->
<!-- I have made corresponding changes to the documentation -->
<!-- I have added tests that prove my fix is effective or that my feature works -->
<!-- New and existing unit tests pass locally with my changes -->

cc @BranchMetrics/saas-sdk-devs for visibility.
